### PR TITLE
feat: tmp tweak to make bun work

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "events": "^3.3.0"
       },
       "devDependencies": {
+        "@types/bun": "^1.2.1",
         "@types/chai": "^5.0.0",
         "@types/mocha": "^10.0.9",
         "@types/node": "^22.7.5",
@@ -628,6 +629,15 @@
         "win32"
       ]
     },
+    "node_modules/@types/bun": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/bun/-/bun-1.2.1.tgz",
+      "integrity": "sha512-iiCeMAKMkft8EPQJxSbpVRD0DKqrh91w40zunNajce3nMNNFd/LnAquVisSZC+UpTMjDwtcdyzbWct08IvEqRA==",
+      "dev": true,
+      "dependencies": {
+        "bun-types": "1.2.1"
+      }
+    },
     "node_modules/@types/chai": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.0.0.tgz",
@@ -769,6 +779,16 @@
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
+    },
+    "node_modules/bun-types": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/bun-types/-/bun-types-1.2.1.tgz",
+      "integrity": "sha512-p7bmXUWmrPWxhcbFVk7oUXM5jAGt94URaoa3qf4mz43MEhNAo/ot1urzBqctgvuq7y9YxkuN51u+/qm4BiIsHw==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "@types/ws": "~8.5.10"
+      }
     },
     "node_modules/camelcase": {
       "version": "6.3.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "author": "Andrew Morris <voltrevo@gmail.com>",
   "license": "MIT",
   "devDependencies": {
+    "@types/bun": "^1.2.1",
     "@types/chai": "^5.0.0",
     "@types/mocha": "^10.0.9",
     "@types/node": "^22.7.5",

--- a/src/ts/secure2PC.ts
+++ b/src/ts/secure2PC.ts
@@ -11,7 +11,7 @@ export default function secure2PC(
   input: Uint8Array,
   io: IO,
 ): Promise<Uint8Array> {
-  if (typeof Worker === 'undefined' || Bun) {
+  if (typeof Worker === 'undefined' || typeof Bun !== 'undefined') {
     return nodeSecure2PC(party, circuit, input, io);
   }
 

--- a/src/ts/secure2PC.ts
+++ b/src/ts/secure2PC.ts
@@ -11,7 +11,7 @@ export default function secure2PC(
   input: Uint8Array,
   io: IO,
 ): Promise<Uint8Array> {
-  if (typeof Worker === 'undefined') {
+  if (typeof Worker === 'undefined' || Bun) {
     return nodeSecure2PC(party, circuit, input, io);
   }
 


### PR DESCRIPTION
## What is this PR doing?

[Bun](https://bun.sh/) is a fast JavaScript runtime, package manager, and bundler, built with Zig for seamless Node.js compatibility and high performance.

This PR makes it work with `emp-wasm`, and as a result with [`mpc-framework`](https://github.com/voltrevo/mpc-framework), with the following tweak, basically following the same path as NodeJS, without Web Workers.

```diff
- if (typeof Worker === 'undefined') {
+ if (typeof Worker === 'undefined' || typeof Bun !== 'undefined') {
```

Bun does support web workers tho, and `Worker` is defined at runtime. However, the content of [workerSrc.ts](https://github.com/voltrevo/emp-wasm/blob/main/src/ts/workerSrc.ts) is replaced with a base64 string at build time: https://github.com/voltrevo/emp-wasm/blob/91a459da5084e641c0ea8009dbb985b3550c7c91/scripts/build.ts#L60-L63

And Bun has limitations on the length of base64 data imports, throwing the following error:

```txt
Error: NameTooLong while resolving package 'data:text/javascript;base64…’
```

 It also does not work if the base64 string is copied directly inside the Worker definition: https://github.com/voltrevo/emp-wasm/blob/91a459da5084e641c0ea8009dbb985b3550c7c91/src/ts/secure2PC.ts#L21

Obviously, if the web worker is used by specifying the file path, But works correctly, but then we would have problems with bundlers.

An alternative solution is to check if Bun is defined and use the web worker with the file path without converting the jslib code to base64, but it would require a few more lines of code in the building script and potentially duplicate files.

## How can these changes be manually tested?

Download Bun, copy `tests/secure2PC.test.ts` to `tests/secure2PC.ts`, remove Mocha syntax and run `bun tests/secure2PC.ts`.

## Does this PR resolve or contribute to any issues?

No.

## Checklist
- [x] I have manually tested these changes
- [ ] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
