### PR TITLE
Improve scale using -sALLOW_MEMORY_GROWTH

### DIFF
--- a/scripts/build_wasm.sh
+++ b/scripts/build_wasm.sh
@@ -40,6 +40,7 @@ em++ programs/jslib.cpp -sASYNCIFY -o build/jslib.js \
   -lmbedcrypto \
   -lmbedx509 \
   -lembind \
+  -sALLOW_MEMORY_GROWTH \
   -s SINGLE_FILE=1 \
   -s ENVIRONMENT='web,worker,node' \
   -sNO_DISABLE_EXCEPTION_CATCHING \


### PR DESCRIPTION
## What is this PR doing?

Adds `-sALLOW_MEMORY_GROWTH` to the emscripten build options.

This allows the runtime to grow the memory buffer assigned to webassembly instead of throwing an exception when it runs out of its approx 25mb allocation.

With this option, the limit is 2gb. Not entirely sure why - it's the default for emscripten, and when I set 4gb as the max instead, it leads to assertion failures.

In terms of circuits, this is about 550,000 AND gates (verified slightly higher) using mpc mode for 2pc, and takes 12min to run on my m1 macbook air between two web workers on the same page.

The reason the test uses mpc mode for 2pc is that in 2pc mode we're running into "FEQ error" once the circuits get to about 5,000 AND gates. 2pc mode seems to use significantly less memory, possibly 7x better but it's a rough approximation based on necessarily small circuits.

## How can these changes be manually tested?

Use this version in `emp-wasm-backend` and add a test using this circuit:

```
      export default function main(x: number) { // use x===0
        function fib(n: number): number {
          if (n <= 1) {
            return n;
          }

          return fib(n - 1) + fib(n - 2) + x;
        }

        // 10: 4511 ANDs, 3210ms
        // 11: 7352 ANDs, 5329ms
        // 12: 11949 ANDs, 8994ms, 76mb
        // 13: 19387 ANDs, 15704ms, 135mb
        // 14: 31422 ANDs, 26914ms, 197mb
        // 15: 50895 ANDs, 52762ms, 297mb
        //..
        // 20: 565302 ANDs, 733139ms

        return fib(20); // fib(20) + fib(12) fails
      }
```

Requires also specifying `mode: 'mpc'` in the `secureMPC` call in `EmpWasmSession.ts`.

## Does this PR resolve or contribute to any issues?

Resolves https://www.notion.so/pse-team/Rough-scale-testing-196d57e8dd7e804c8a80c2556c5ab856?pvs=4.

## Checklist
- [x] I have manually tested these changes
- [ ] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
