### PR TITLE
fix nextjs by preventing static analysis of import

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "emp-wasm",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "emp-wasm",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MIT",
       "dependencies": {
         "ee-typed": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "emp-wasm",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Wasm build of authenticated garbling from [emp-toolkit/emp-ag2pc](https://github.com/emp-toolkit/emp-ag2pc).",
   "type": "module",
   "main": "dist/src/ts/index.js",


### PR DESCRIPTION
## What is this PR doing?

See title.

## How can these changes be manually tested?

`npm build`, `npm test`
also `npm pack` and install the tgz into `emp-wasm-backend`, run the tests in there, and also `deno run --unstable-sloppy-imports tests/mpc.test.ts`
also copy `dist/build/jslib.js` into the node_modules copy of this file in the nextjs variant of mpc-hello, `rm -rf .next` and `npm run dev`, check that works too

## Does this PR resolve or contribute to any issues?

Contributes to https://www.notion.so/pse-team/Update-internal-dependencies-including-summon-ts-1d0d57e8dd7e8039bab8f77ea74ddb68?pvs=4

## Checklist
- [x] I have manually tested these changes
- [ ] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
